### PR TITLE
kernel/trace: multiple improvements

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -9,7 +9,8 @@ pciem-objs := framework/pciem.o \
               framework/userspace.o \
               framework/pool.o
 
-pciem-objs += trace/smptrace.o
+pciem-objs += trace/smptrace.o \
+              trace/arch/$(ARCH)/smptrace_arch.o
 
 ifeq ($(ARCH),x86)
 pciem-objs += trace/arch/x86/lib/insn.o \

--- a/kernel/include/trace/smptrace.h
+++ b/kernel/include/trace/smptrace.h
@@ -51,6 +51,8 @@ struct smptrace_map {
 	unsigned long va;
 	unsigned long len;
 	resource_size_t pa;
+	/* Un-poisoned PTEs */
+	struct list_head ptes;
 };
 
 struct smptrace_ctx {
@@ -80,8 +82,6 @@ struct smptrace_ctx {
 	/* Protects structural modifications to the lists */
 	spinlock_t lock;
 
-	/* Un-poisoned PTEs */
-	struct list_head ptes;
 	/* Active mapped VA regions */
 	struct list_head maps;
 

--- a/kernel/include/trace/smptrace_internal.h
+++ b/kernel/include/trace/smptrace_internal.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ *  Copyright (C) 2026  Carlos López <carlos.lopezr4096@gmail.com>
+ *  Copyright (C) 2026  Joel Bueno <buenocalvachejoel@gmail.com>
+ */
+#ifndef _PCIEM_SMPTRACE_INTERNAL
+#define _PCIEM_SMPTRACE_INTERNAL
+#include "trace/smptrace.h"
+
+struct ioremap_args {
+	resource_size_t pa;
+	unsigned long len;
+};
+
+static void __used smptrace_ret_gadget(void) {}
+
+static inline struct smptrace_pte *
+smptrace_find_pte(struct smptrace_map *map, unsigned long va)
+{
+	struct smptrace_pte *tmp;
+
+	list_for_each_entry(tmp, &map->ptes, list) {
+		if (tmp->va == va)
+			return tmp;
+	}
+	return NULL;
+}
+
+int smptrace_register_probes(struct smptrace_ctx *ctx);
+int smptrace_enter_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs);
+int smptrace_exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs);
+int smptrace_enter_iounmap(struct kprobe *rp, struct pt_regs *regs);
+void smptrace_emulate_write(struct smptrace_ctx *ctx, struct smptrace_map *map,
+                            u64 addr, u32 size, const u8 *src);
+void smptrace_emulate_read(struct smptrace_ctx *ctx, struct smptrace_map *map,
+                           u64 addr, u32 size, u8 *dst);
+
+/* Arch-specific functionality. Architectures must implement these in order
+ * to be supported by smptrace */
+
+int smptrace_arch_activate(struct smptrace_ctx *ctx);
+int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
+void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
+
+#endif

--- a/kernel/trace/arch/arm64/smptrace_arch.c
+++ b/kernel/trace/arch/arm64/smptrace_arch.c
@@ -102,16 +102,12 @@ static unsigned long arm64_level2size(unsigned int level)
  * This also overcomes the limitation of certain unexported functions (That
  * would probably make this much more cleaner...) erroring out on modpost.
  */
-static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
-                      unsigned int len)
+static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
-	int64_t remain = len;
+	unsigned long va = map->va;
+	int64_t remain = map->len;
 	struct smptrace_pte *orig, *tmp;
-	struct list_head local_ptes;
-	unsigned long flags;
 	int ret;
-
-	INIT_LIST_HEAD(&local_ptes);
 
 	while (remain > 0) {
 		unsigned int level;
@@ -151,34 +147,28 @@ static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
 
 		remain -= arm64_level2size(level);
 		va     += arm64_level2size(level);
-		list_add_tail(&orig->list, &local_ptes);
+		list_add_tail(&orig->list, &map->ptes);
 	}
 
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_splice_tail(&local_ptes, &ctx->ptes);
-	spin_unlock_irqrestore(&ctx->lock, flags);
-
-	flush_tlb_kernel_range(va - len, va);
+	flush_tlb_kernel_range(map->va, va);
 	return 0;
 
 fail:
-	list_for_each_entry_safe(orig, tmp, &local_ptes, list) {
+	list_for_each_entry_safe(orig, tmp, &map->ptes, list) {
 		list_del(&orig->list);
 		kfree(orig);
 	}
-	flush_tlb_kernel_range(va - (len - remain), va);
+	flush_tlb_kernel_range(va - (map->len - remain), va);
 	return ret;
 }
 
 /*
  * Restore the PTEs corresponding to the given VA range.
  */
-static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
-                        unsigned int len)
+static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
-	int64_t remain = len;
-	unsigned long va_start = va;
-	unsigned long flags;
+	unsigned long va = map->va;
+	int64_t remain = map->len;
 
 	while (remain > 0) {
 		unsigned int level;
@@ -194,18 +184,15 @@ static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
 
 		step = arm64_level2size(level);
 
-		spin_lock_irqsave(&ctx->lock, flags);
-		orig = __find_pte(ctx, va);
-		if (orig)
-			list_del(&orig->list);
-		spin_unlock_irqrestore(&ctx->lock, flags);
-
+		orig = __find_pte(map, va);
 		if (!orig) {
 			pr_err("could not find saved PTE for va=0x%lx\n", va);
 			remain -= step;
 			va     += step;
 			continue;
 		}
+
+		list_del(&orig->list);
 
 		if (orig->level != level)
 			pr_warn("PTE level mismatch for va=0x%lx (saved=%u walk=%u)",
@@ -230,7 +217,7 @@ static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
 		kfree(orig);
 	}
 
-	flush_tlb_kernel_range(va_start, va_start + len);
+	flush_tlb_kernel_range(map->va, map->va + map->len);
 }
 
 struct arm64_ls_insn {

--- a/kernel/trace/arch/arm64/smptrace_arch.c
+++ b/kernel/trace/arch/arm64/smptrace_arch.c
@@ -4,10 +4,12 @@
  *  Copyright (C) 2026  Joel Bueno <buenocalvachejoel@gmail.com>
  */
 
+#include <linux/kprobes.h>
 #include <asm/traps.h>
 #include <asm/pgtable-hwdef.h>
 #include <asm/sysreg.h>
 #include <asm/esr.h>
+#include "trace/smptrace_internal.h"
 
 #define SMPTRACE_ARM64_LEVEL_PTE  0
 #define SMPTRACE_ARM64_LEVEL_PMD  1
@@ -102,7 +104,7 @@ static unsigned long arm64_level2size(unsigned int level)
  * This also overcomes the limitation of certain unexported functions (That
  * would probably make this much more cleaner...) erroring out on modpost.
  */
-static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;
@@ -165,7 +167,7 @@ fail:
 /*
  * Restore the PTEs corresponding to the given VA range.
  */
-static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;
@@ -184,7 +186,7 @@ static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 
 		step = arm64_level2size(level);
 
-		orig = __find_pte(map, va);
+		orig = smptrace_find_pte(map, va);
 		if (!orig) {
 			pr_err("could not find saved PTE for va=0x%lx\n", va);
 			remain -= step;
@@ -376,10 +378,10 @@ static int emulate_arm64_fault(struct smptrace_ctx *ctx,
 
 	if (is_store) {
 		val = (srt == 31) ? 0ULL : regs->regs[srt];
-		emulate_write(ctx, map, addr, size, (u8 *)&val);
+		smptrace_emulate_write(ctx, map, addr, size, (u8 *)&val);
 	} else {
 		val = 0;
-		emulate_read(ctx, map, addr, size, (u8 *)&val);
+		smptrace_emulate_read(ctx, map, addr, size, (u8 *)&val);
 
 		if (srt != 31) {
 			if (sse) {
@@ -451,7 +453,7 @@ static int __enter_do_kernel_fault(struct kprobe *kp, struct pt_regs *regs)
 	return 0;
 }
 
-static int smptrace_activate(struct smptrace_ctx *ctx)
+int smptrace_arch_activate(struct smptrace_ctx *ctx)
 {
 	ctx->shadow_va = ioremap(ctx->pa, ctx->len);
 	if (!ctx->shadow_va) {
@@ -465,12 +467,12 @@ static int smptrace_activate(struct smptrace_ctx *ctx)
 		.symbol_name = "__do_kernel_fault",
 	};
 	ctx->iounmap_kp = (struct kprobe){
-		.pre_handler = __enter_iounmap,
+		.pre_handler = smptrace_enter_iounmap,
 		.symbol_name = "iounmap",
 	};
 	ctx->ioremap_krp = (struct kretprobe){
-		.entry_handler  = __enter_ioremap,
-		.handler        = __exit_ioremap,
+		.entry_handler  = smptrace_enter_ioremap,
+		.handler        = smptrace_exit_ioremap,
 		.maxactive      = 32,
 		.data_size      = sizeof(struct ioremap_args),
 		.kp.symbol_name = "ioremap_prot",

--- a/kernel/trace/arch/riscv/smptrace_arch.c
+++ b/kernel/trace/arch/riscv/smptrace_arch.c
@@ -101,16 +101,12 @@ static unsigned long riscv_level2size(unsigned int level)
 	}
 }
 
-static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
-                      unsigned int len)
+static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
-	int64_t remain = len;
+	unsigned long va = map->va;
+	int64_t remain = map->len;
 	struct smptrace_pte *orig, *tmp;
-	struct list_head local_ptes;
-	unsigned long flags;
 	int ret;
-
-	INIT_LIST_HEAD(&local_ptes);
 
 	while (remain > 0) {
 		unsigned int level;
@@ -150,18 +146,14 @@ static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
 
 		remain -= riscv_level2size(level);
 		va     += riscv_level2size(level);
-		list_add_tail(&orig->list, &local_ptes);
+		list_add_tail(&orig->list, &map->ptes);
 	}
-
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_splice_tail(&local_ptes, &ctx->ptes);
-	spin_unlock_irqrestore(&ctx->lock, flags);
 
 	on_each_cpu(riscv_smptrace_sfence, NULL, 1);
 	return 0;
 
 fail:
-	list_for_each_entry_safe(orig, tmp, &local_ptes, list) {
+	list_for_each_entry_safe(orig, tmp, &map->ptes, list) {
 		list_del(&orig->list);
 		kfree(orig);
 	}
@@ -169,11 +161,10 @@ fail:
 	return ret;
 }
 
-static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
-                        unsigned int len)
+static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
-	int64_t remain = len;
-	unsigned long flags;
+	unsigned long va = map->va;
+	int64_t remain = map->len;
 
 	while (remain > 0) {
 		unsigned int level;
@@ -189,18 +180,15 @@ static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
 
 		step = riscv_level2size(level);
 
-		spin_lock_irqsave(&ctx->lock, flags);
-		orig = __find_pte(ctx, va);
-		if (orig)
-			list_del(&orig->list);
-		spin_unlock_irqrestore(&ctx->lock, flags);
-
+		orig = __find_pte(map, va);
 		if (!orig) {
 			pr_err("could not find saved PTE for va=0x%lx\n", va);
 			remain -= step;
 			va     += step;
 			continue;
 		}
+
+		list_del(&orig->list);
 
 		if (orig->level != level)
 			pr_warn("PTE level mismatch for va=0x%lx (saved=%u walk=%u)",

--- a/kernel/trace/arch/riscv/smptrace_arch.c
+++ b/kernel/trace/arch/riscv/smptrace_arch.c
@@ -4,6 +4,7 @@
  *  Copyright (C) 2026  Joel Bueno <buenocalvachejoel@gmail.com>
  */
 #include <asm/csr.h>
+#include "trace/smptrace_internal.h"
 
 #define SMPTRACE_RISCV_LEVEL_PTE  0
 #define SMPTRACE_RISCV_LEVEL_PMD  1
@@ -101,7 +102,7 @@ static unsigned long riscv_level2size(unsigned int level)
 	}
 }
 
-static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;
@@ -161,7 +162,7 @@ fail:
 	return ret;
 }
 
-static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;
@@ -180,7 +181,7 @@ static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 
 		step = riscv_level2size(level);
 
-		orig = __find_pte(map, va);
+		orig = smptrace_find_pte(map, va);
 		if (!orig) {
 			pr_err("could not find saved PTE for va=0x%lx\n", va);
 			remain -= step;
@@ -429,10 +430,10 @@ static int emulate_riscv_fault(struct smptrace_ctx *ctx,
 
 	if (ls.is_store) {
 		unsigned long src = riscv_get_reg(regs, ls.rs2);
-		emulate_write(ctx, map, fault_va, ls.size, (u8 *)&src);
+		smptrace_emulate_write(ctx, map, fault_va, ls.size, (u8 *)&src);
 	} else {
 		val = 0;
-		emulate_read(ctx, map, fault_va, ls.size, (u8 *)&val);
+		smptrace_emulate_read(ctx, map, fault_va, ls.size, (u8 *)&val);
 
 		if (ls.rd != 0) {
 			if (ls.sign_extend) {
@@ -500,7 +501,7 @@ static int __enter_riscv_handle_page_fault(struct kprobe *kp,
 	return 0;
 }
 
-static int smptrace_activate(struct smptrace_ctx *ctx)
+int smptrace_arch_activate(struct smptrace_ctx *ctx)
 {
 	// Maybe we could do w/o SATP but it should point to kernel page tables on this context
 	ctx->riscv_kernel_satp = csr_read(CSR_SATP);
@@ -521,12 +522,12 @@ static int smptrace_activate(struct smptrace_ctx *ctx)
 		.symbol_name = "handle_page_fault",
 	};
 	ctx->iounmap_kp = (struct kprobe){
-		.pre_handler = __enter_iounmap,
+		.pre_handler = smptrace_enter_iounmap,
 		.symbol_name = "iounmap",
 	};
 	ctx->ioremap_krp = (struct kretprobe){
-		.entry_handler  = __enter_ioremap,
-		.handler        = __exit_ioremap,
+		.entry_handler  = smptrace_enter_ioremap,
+		.handler        = smptrace_exit_ioremap,
 		.maxactive      = 32,
 		.data_size      = sizeof(struct ioremap_args),
 		.kp.symbol_name = "ioremap_prot",

--- a/kernel/trace/arch/x86/smptrace_arch.c
+++ b/kernel/trace/arch/x86/smptrace_arch.c
@@ -7,8 +7,10 @@
 #include <asm/debugreg.h>
 #include <asm/traps.h>
 #include <asm/pgtable.h>
+#include <linux/version.h>
 #include "insn.h"
 #include "insn-eval.h"
+#include "trace/smptrace_internal.h"
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
 static inline pud_t pud_mkinvalid(pud_t pud)
@@ -40,7 +42,7 @@ static u64 level2size(unsigned int level)
 	}
 }
 
-static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
 	int64_t remain = map->len;
 	unsigned long va = map->va;
@@ -117,7 +119,7 @@ fail:
 	return ret;
 }
 
-static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;
@@ -133,7 +135,7 @@ static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 			continue;
 		}
 
-		orig = __find_pte(map, va);
+		orig = smptrace_find_pte(map, va);
 		if (!orig) {
 			pr_err("could not find saved PTE for va=0x%lx\n", va);
 			remain -= level2size(level);
@@ -225,34 +227,34 @@ static int emulate_pf_instruction(struct smptrace_ctx *ctx,
 
 	switch (mmio) {
 	case INSN_MMIO_WRITE:
-		emulate_write(ctx, map, addr, len, (u8 *)data);
+		smptrace_emulate_write(ctx, map, addr, len, (u8 *)data);
 		break;
 	case INSN_MMIO_WRITE_IMM:
 		BUG_ON(len > 4);
-		emulate_write(ctx, map, addr, len, (u8 *)insn.immediate1.bytes);
+		smptrace_emulate_write(ctx, map, addr, len, (u8 *)insn.immediate1.bytes);
 		break;
 	case INSN_MMIO_READ:
 		if (len == 4)
 			*data = 0;
-		emulate_read(ctx, map, addr, len, (u8 *)data);
+		smptrace_emulate_read(ctx, map, addr, len, (u8 *)data);
 		break;
 	case INSN_MMIO_READ_ZERO_EXTEND:
 		memset(data, 0, insn.opnd_bytes);
-		emulate_read(ctx, map, addr, len, (u8 *)data);
+		smptrace_emulate_read(ctx, map, addr, len, (u8 *)data);
 		break;
 	case INSN_MMIO_READ_SIGN_EXTEND:
         /* Sign extend based on operand size */
 		if (len == 1) {
 			u8 val;
-			emulate_read(ctx, map, addr, len, &val);
+			smptrace_emulate_read(ctx, map, addr, len, &val);
 			sign_byte = (val & 0x80) ? 0xff : 0x00;
 		} else {
 			u16 val;
-			emulate_read(ctx, map, addr, len, (u8 *)&val);
+			smptrace_emulate_read(ctx, map, addr, len, (u8 *)&val);
 			sign_byte = (val & 0x8000) ? 0xff : 0x00;
 		}
 		memset(data, sign_byte, insn.opnd_bytes);
-		emulate_read(ctx, map, addr, len, (u8 *)data);
+		smptrace_emulate_read(ctx, map, addr, len, (u8 *)data);
 		break;
 	case INSN_MMIO_MOVS:
 		pr_warn_ratelimited("unhandled MOVS instruction ip=0x%lx", regs->ip);
@@ -309,7 +311,7 @@ static int __enter_badarea(struct kprobe *kp, struct pt_regs *regs)
 	return 0;
 }
 
-static int smptrace_activate(struct smptrace_ctx *ctx)
+int smptrace_arch_activate(struct smptrace_ctx *ctx)
 {
 	ctx->shadow_va = ioremap(ctx->pa, ctx->len);
 	if (!ctx->shadow_va) {
@@ -324,12 +326,12 @@ static int smptrace_activate(struct smptrace_ctx *ctx)
 		.symbol_name = "bad_area_nosemaphore",
 	};
 	ctx->iounmap_kp = (struct kprobe){
-		.pre_handler = __enter_iounmap,
+		.pre_handler = smptrace_enter_iounmap,
 		.symbol_name = "iounmap",
 	};
 	ctx->ioremap_krp = (struct kretprobe){
-		.entry_handler  = __enter_ioremap,
-		.handler        = __exit_ioremap,
+		.entry_handler  = smptrace_enter_ioremap,
+		.handler        = smptrace_exit_ioremap,
 		.maxactive      = 32,
 		.data_size      = sizeof(struct ioremap_args),
 		.kp.symbol_name = "ioremap",

--- a/kernel/trace/arch/x86/smptrace_arch.c
+++ b/kernel/trace/arch/x86/smptrace_arch.c
@@ -40,17 +40,13 @@ static u64 level2size(unsigned int level)
 	}
 }
 
-static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
-                      unsigned int len)
+static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
-	int64_t remain = len;
+	int64_t remain = map->len;
+	unsigned long va = map->va;
 	unsigned int level;
 	struct smptrace_pte *orig, *tmp;
-	struct list_head local_ptes;
-	unsigned long flags;
 	int ret;
-
-	INIT_LIST_HEAD(&local_ptes);
 
 	while (remain > 0) {
 		pte_t *ptep = lookup_address(va, &level);
@@ -70,7 +66,7 @@ static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
 		orig->va    = va;
 		orig->level = level;
 
-        /* Swap out PTE */
+		/* Swap out PTE */
 		switch (level) {
 		case PG_LEVEL_4K: {
 			pte_t pte = native_local_ptep_get_and_clear(ptep);
@@ -103,12 +99,8 @@ static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
 
 		remain -= level2size(level);
 		va     += level2size(level);
-		list_add_tail(&orig->list, &local_ptes);
+		list_add_tail(&orig->list, &map->ptes);
 	}
-
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_splice_tail(&local_ptes, &ctx->ptes);
-	spin_unlock_irqrestore(&ctx->lock, flags);
 
 	__flush_tlb();
 	return 0;
@@ -117,7 +109,7 @@ fail:
 	/* Free items, but do not bother to unpoison the PTEs. Let our
 	 * caller detect the error, and simply return NULL to the caller
 	 * of ioremap() */
-	list_for_each_entry_safe(orig, tmp, &local_ptes, list) {
+	list_for_each_entry_safe(orig, tmp, &map->ptes, list) {
 		list_del(&orig->list);
 		kfree(orig);
 	}
@@ -125,11 +117,10 @@ fail:
 	return ret;
 }
 
-static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
-                        unsigned int len)
+static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
-	int64_t remain = len;
-	unsigned long flags;
+	unsigned long va = map->va;
+	int64_t remain = map->len;
 
 	while (remain > 0) {
 		unsigned int level;
@@ -142,18 +133,15 @@ static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
 			continue;
 		}
 
-		spin_lock_irqsave(&ctx->lock, flags);
-		orig = __find_pte(ctx, va);
-		if (orig)
-			list_del(&orig->list);
-		spin_unlock_irqrestore(&ctx->lock, flags);
-
+		orig = __find_pte(map, va);
 		if (!orig) {
 			pr_err("could not find saved PTE for va=0x%lx\n", va);
 			remain -= level2size(level);
 			va     += level2size(level);
 			continue;
 		}
+
+		list_del(&orig->list);
 
 		if (orig->level != level)
 			pr_warn("PTE level mismatch for va=0x%lx (saved=%u walk=%u)",

--- a/kernel/trace/smptrace.c
+++ b/kernel/trace/smptrace.c
@@ -148,14 +148,7 @@ static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	pr_info("poisoning VA=0x%lx:%lx (PA=0x%llx:%lx)",
 	        va, args->len, (unsigned long long)ctx->pa, ctx->len);
 
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_add_tail(&map->list, &ctx->maps);
-	spin_unlock_irqrestore(&ctx->lock, flags);
-
 	if (poison_pte(ctx, va, args->len)) {
-		spin_lock_irqsave(&ctx->lock, flags);
-		list_del(&map->list);
-		spin_unlock_irqrestore(&ctx->lock, flags);
 		kfree(map);
 
 		regs_set_return_value(regs, 0);
@@ -163,6 +156,10 @@ static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 
 		pr_warn("failed to poison VA=0x%lx:%lx (PA=0x%llx:%lx)",
 		        va, args->len, args->pa, args->len);
+	} else {
+		spin_lock_irqsave(&ctx->lock, flags);
+		list_add_tail(&map->list, &ctx->maps);
+		spin_unlock_irqrestore(&ctx->lock, flags);
 	}
 
 	return 0;

--- a/kernel/trace/smptrace.c
+++ b/kernel/trace/smptrace.c
@@ -45,6 +45,7 @@
 #include <asm/io.h>
 #include <asm/tlbflush.h>
 #include "trace/smptrace.h"
+#include "trace/smptrace_internal.h"
 
 static void __fill_io_notif(struct smptrace_io *io, const u8 *data, u32 size,
                             u64 off)
@@ -69,7 +70,7 @@ static void __fill_io_notif(struct smptrace_io *io, const u8 *data, u32 size,
 	}
 }
 
-static void emulate_read(struct smptrace_ctx *ctx, struct smptrace_map *map,
+void smptrace_emulate_read(struct smptrace_ctx *ctx, struct smptrace_map *map,
                          u64 addr, u32 size, u8 *dst)
 {
 	u64 off;
@@ -85,7 +86,7 @@ static void emulate_read(struct smptrace_ctx *ctx, struct smptrace_map *map,
 	}
 }
 
-static void emulate_write(struct smptrace_ctx *ctx, struct smptrace_map *map,
+void smptrace_emulate_write(struct smptrace_ctx *ctx, struct smptrace_map *map,
                           u64 addr, u32 size, const u8 *src)
 {
 	u64 off;
@@ -105,12 +106,7 @@ static void emulate_write(struct smptrace_ctx *ctx, struct smptrace_map *map,
 	}
 }
 
-struct ioremap_args {
-	resource_size_t pa;
-	unsigned long len;
-};
-
-static int __enter_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
+int smptrace_enter_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct ioremap_args *args = (struct ioremap_args *)ri->data;
 
@@ -119,10 +115,7 @@ static int __enter_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	return 0;
 }
 
-static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
-static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
-
-static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
+int smptrace_exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
 	struct kretprobe *rp = get_kretprobe(ri);
 	struct smptrace_ctx *ctx = container_of(rp, struct smptrace_ctx,
@@ -147,7 +140,7 @@ static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	pr_info("poisoning VA=0x%lx:%lx (PA=0x%llx:%lx)",
 	        va, args->len, (unsigned long long)ctx->pa, ctx->len);
 
-	if (poison_pte(ctx, map)) {
+	if (smptrace_arch_poison_pte(ctx, map)) {
 		kfree(map);
 
 		regs_set_return_value(regs, 0);
@@ -164,7 +157,7 @@ static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	return 0;
 }
 
-static int __enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
+int smptrace_enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
 {
 	struct smptrace_ctx *ctx = container_of(kp, struct smptrace_ctx,
 	                                        iounmap_kp);
@@ -187,25 +180,12 @@ static int __enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
 
 	pr_info("restoring VA=0x%lx (PA=0x%llx)", found->va,
 	        (unsigned long long)found->pa);
-	restore_pte(ctx, found);
+	smptrace_arch_restore_pte(ctx, found);
 	kfree(found);
 	return 0;
 }
 
-static struct smptrace_pte *__find_pte(struct smptrace_map *map, unsigned long va)
-{
-	struct smptrace_pte *tmp;
-
-	list_for_each_entry(tmp, &map->ptes, list) {
-		if (tmp->va == va)
-			return tmp;
-	}
-	return NULL;
-}
-
-static void __used smptrace_ret_gadget(void) {}
-
-static int smptrace_register_probes(struct smptrace_ctx *ctx)
+int smptrace_register_probes(struct smptrace_ctx *ctx)
 {
 	int ret;
 
@@ -242,27 +222,6 @@ fail_badarea:
 	return ret;
 }
 
-/*
- * Each backend must provide:
- *   static int  poison_pte(struct smptrace_ctx *, struct smptrace_map *);
- *   static void restore_pte(struct smptrace_ctx *, struct smptrace_map *);
- *   static int  smptrace_activate(struct smptrace_ctx *);
- *
- * Backends may freely call emulate_read(), emulate_write(), __find_pte(),
- * smptrace_ret_gadget(), smptrace_register_probes(), __enter_ioremap(),
- * __exit_ioremap(), and __enter_iounmap().
- */
-
-#if defined(CONFIG_X86)
-#include "arch/x86/smptrace_arch.c"
-#elif defined(CONFIG_ARM64)
-#include "arch/arm64/smptrace_arch.c"
-#elif defined(CONFIG_RISCV)
-#include "arch/riscv/smptrace_arch.c"
-#else
-#error "smptrace: unsupported architecture"
-#endif
-
 int smptrace_init(struct smptrace_ctx *ctx)
 {
 	int ret;
@@ -274,7 +233,7 @@ int smptrace_init(struct smptrace_ctx *ctx)
 	if (!ctx->in_pf)
 		return -ENOMEM;
 
-	ret = smptrace_activate(ctx);
+	ret = smptrace_arch_activate(ctx);
 	if (ret) {
 		free_percpu(ctx->in_pf);
 		return ret;
@@ -301,7 +260,7 @@ static void smptrace_deactivate(struct smptrace_ctx *ctx)
 		list_del(&map->list);
 		spin_unlock_irqrestore(&ctx->lock, flags);
 
-		restore_pte(ctx, map);
+		smptrace_arch_restore_pte(ctx, map);
 		kfree(map);
 
 		spin_lock_irqsave(&ctx->lock, flags);

--- a/kernel/trace/smptrace.c
+++ b/kernel/trace/smptrace.c
@@ -119,10 +119,8 @@ static int __enter_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	return 0;
 }
 
-static int poison_pte(struct smptrace_ctx *ctx, unsigned long va,
-                      unsigned int len);
-static void restore_pte(struct smptrace_ctx *ctx, unsigned long va,
-                        unsigned int len);
+static int poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
+static void restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
 
 static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 {
@@ -144,11 +142,12 @@ static int __exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	map->va  = va;
 	map->len = args->len;
 	map->pa  = args->pa;
+	INIT_LIST_HEAD(&map->ptes);
 
 	pr_info("poisoning VA=0x%lx:%lx (PA=0x%llx:%lx)",
 	        va, args->len, (unsigned long long)ctx->pa, ctx->len);
 
-	if (poison_pte(ctx, va, args->len)) {
+	if (poison_pte(ctx, map)) {
 		kfree(map);
 
 		regs_set_return_value(regs, 0);
@@ -188,16 +187,16 @@ static int __enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
 
 	pr_info("restoring VA=0x%lx (PA=0x%llx)", found->va,
 	        (unsigned long long)found->pa);
-	restore_pte(ctx, found->va, found->len);
+	restore_pte(ctx, found);
 	kfree(found);
 	return 0;
 }
 
-static struct smptrace_pte *__find_pte(struct smptrace_ctx *ctx, unsigned long va)
+static struct smptrace_pte *__find_pte(struct smptrace_map *map, unsigned long va)
 {
 	struct smptrace_pte *tmp;
 
-	list_for_each_entry(tmp, &ctx->ptes, list) {
+	list_for_each_entry(tmp, &map->ptes, list) {
 		if (tmp->va == va)
 			return tmp;
 	}
@@ -245,8 +244,8 @@ fail_badarea:
 
 /*
  * Each backend must provide:
- *   static int  poison_pte(struct smptrace_ctx *, unsigned long va, unsigned int len);
- *   static void restore_pte(struct smptrace_ctx *, unsigned long va, unsigned int len);
+ *   static int  poison_pte(struct smptrace_ctx *, struct smptrace_map *);
+ *   static void restore_pte(struct smptrace_ctx *, struct smptrace_map *);
  *   static int  smptrace_activate(struct smptrace_ctx *);
  *
  * Backends may freely call emulate_read(), emulate_write(), __find_pte(),
@@ -268,7 +267,6 @@ int smptrace_init(struct smptrace_ctx *ctx)
 {
 	int ret;
 
-	INIT_LIST_HEAD(&ctx->ptes);
 	INIT_LIST_HEAD(&ctx->maps);
 	spin_lock_init(&ctx->lock);
 
@@ -303,7 +301,7 @@ static void smptrace_deactivate(struct smptrace_ctx *ctx)
 		list_del(&map->list);
 		spin_unlock_irqrestore(&ctx->lock, flags);
 
-		restore_pte(ctx, map->va, map->len);
+		restore_pte(ctx, map);
 		kfree(map);
 
 		spin_lock_irqsave(&ctx->lock, flags);


### PR DESCRIPTION
Several improvements for smptrace:
* Simplify cleanup during `__exit_ioremap()` if `poison_pte()` fails.
* Clean up how unpoisoned PTEs are stored in order to reduce lock contention and simplify PTE poison/restore.
* Formalize the division between architecture-specific and generic code.