### PR TITLE
include/pciem_api: fix shared_ring doc-comment to match code

### DIFF
--- a/include/pciem_api.h
+++ b/include/pciem_api.h
@@ -315,15 +315,15 @@ struct pciem_trace_bar
  * Lock-free single-producer/single-consumer event ring shared between the
  * kernel and userspace.
  *
- * The kernel writes events by advancing @head; userspace consumes them by
- * advancing @tail. Each counter is cache-line padded.
+ * The kernel writes events by advancing @tail; userspace consumes them by
+ * advancing @head. Each counter is cache-line padded.
  * The ring is mapped read-only into userspace via mmap on the PCIem fd.
  *
- * @param head    Write index, owned by the kernel. Incremented atomically
- *                after each event is committed.
- * @param _pad1   Cache-line padding to isolate @head from @tail.
- * @param tail    Read index, owned by userspace. Incremented after each event
+ * @param head    Read index, owned by userspace. Incremented after each event
  *                is consumed.
+ * @param _pad1   Cache-line padding to isolate @head from @tail.
+ * @param tail    Write index, owned by the kernel. Incremented atomically
+ *                after each event is committed.
  * @param _pad2   Cache-line padding to isolate @tail from the event array.
  * @param events  Circular buffer of PCIEM_RING_SIZE events.
  */


### PR DESCRIPTION
The struct comment on ` pciem_shared_ring ` in ` include/pciem_api.h ` describes the kernel as the producer (advancing ` @head `) and userspace as the consumer (advancing ` @tail `):

```c
 * The kernel writes events by advancing @head; userspace consumes them by
 * advancing @tail. Each counter is cache-line padded.
 *
 * @param head    Write index, owned by the kernel. Incremented atomically
 *                after each event is committed.
 * ...
 * @param tail    Read index, owned by userspace. Incremented after each event
 *                is consumed.
```

The implementation is the opposite: ` pciem_shared_ring_push ` in ` kernel/framework/userspace.c ` advances ` @tail ` on push, and the ` protopciem ` example daemon consumes by advancing ` @head `.

Swap the prose so it agrees with the code (kernel = ` @tail `, userspace = ` @head `). No code change.