### PR TITLE
fix: bar index extraction in pciem_instance_mmap

### DIFF
--- a/kernel/framework/userspace.c
+++ b/kernel/framework/userspace.c
@@ -143,7 +143,7 @@ static int pciem_instance_mmap(struct file *file, struct vm_area_struct *vma)
     struct pciem_bar_info *bar;
     struct pciem_root_complex *v;
     unsigned long size = vma->vm_end - vma->vm_start;
-    unsigned long bar_index = vma->vm_pgoff & (PCI_STD_NUM_BARS - 1);
+    unsigned long bar_index = vma->vm_pgoff & ((1 << 3) - 1);
     unsigned long func_index = vma->vm_pgoff >> 3;
 
     if (!us)


### PR DESCRIPTION
Fix BAR index extraction in the `pciem_instance_mmap` function.
Currently the bitmask `(PCI_STD_NUM_BARS - 1)` evaluates to `5` which causes bit 1 to be zeroed, and thus BAR2 maps to BAR0 and BAR3 maps to BAR1.
BAR6 and BAR7 are incorrectly mapping to BAR4 and BAR5 as well, instead of being rejected.