### PR TITLE
kernel: trace: use RCU to improve instruction emulation and other cleanups

### DIFF
--- a/kernel/include/trace/smptrace.h
+++ b/kernel/include/trace/smptrace.h
@@ -8,6 +8,7 @@
 #include <asm/pgtable.h>
 #include <linux/kprobes.h>
 #include <linux/compiler.h>
+#include <linux/rcupdate.h>
 
 union smptrace_data {
 	u8 raw[8];
@@ -53,6 +54,7 @@ struct smptrace_map {
 	resource_size_t pa;
 	/* Un-poisoned PTEs */
 	struct list_head ptes;
+	struct rcu_head rcu;
 };
 
 struct smptrace_ctx {

--- a/kernel/include/trace/smptrace.h
+++ b/kernel/include/trace/smptrace.h
@@ -67,16 +67,6 @@ struct smptrace_ctx {
 	/* Whether to emulate writes into the BAR */
 	bool stop_writes;
 
-#ifdef CONFIG_RISCV
-    /*
-     * Snapshotted SATP value within kernel context.
-	 *
-	 * Helps us avoid pulling certain symbols that would
-	 * make modpost complain.
-     */
-    unsigned long riscv_kernel_satp;
-#endif
-
 	/*** Do not touch below here ***/
 
 	/* Protects structural modifications to the lists */

--- a/kernel/include/trace/smptrace_internal.h
+++ b/kernel/include/trace/smptrace_internal.h
@@ -39,7 +39,7 @@ void smptrace_emulate_read(struct smptrace_ctx *ctx, struct smptrace_map *map,
  * to be supported by smptrace */
 
 int smptrace_arch_activate(struct smptrace_ctx *ctx);
-int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
-void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map);
+int smptrace_arch_poison_pte(struct smptrace_map *map);
+void smptrace_arch_restore_pte(struct smptrace_map *map);
 
 #endif

--- a/kernel/include/trace/smptrace_internal.h
+++ b/kernel/include/trace/smptrace_internal.h
@@ -26,6 +26,24 @@ smptrace_find_pte(struct smptrace_map *map, unsigned long va)
 	return NULL;
 }
 
+static inline bool smptrace_find_map_rcu(struct smptrace_ctx *ctx,
+					  unsigned long va, struct smptrace_map *dst)
+{
+	struct smptrace_map *tmp_map;
+
+	guard(rcu)();
+
+	list_for_each_entry_rcu(tmp_map, &ctx->maps, list) {
+		if (va >= tmp_map->va && va < tmp_map->va + tmp_map->len) {
+			*dst = *tmp_map;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
 int smptrace_register_probes(struct smptrace_ctx *ctx);
 int smptrace_enter_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs);
 int smptrace_exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs);

--- a/kernel/trace/arch/arm64/smptrace_arch.c
+++ b/kernel/trace/arch/arm64/smptrace_arch.c
@@ -104,7 +104,7 @@ static unsigned long arm64_level2size(unsigned int level)
  * This also overcomes the limitation of certain unexported functions (That
  * would probably make this much more cleaner...) erroring out on modpost.
  */
-int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+int smptrace_arch_poison_pte(struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;
@@ -167,7 +167,7 @@ fail:
 /*
  * Restore the PTEs corresponding to the given VA range.
  */
-void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+void smptrace_arch_restore_pte(struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;

--- a/kernel/trace/arch/arm64/smptrace_arch.c
+++ b/kernel/trace/arch/arm64/smptrace_arch.c
@@ -413,27 +413,14 @@ static int __enter_do_kernel_fault(struct kprobe *kp, struct pt_regs *regs)
 	unsigned long esr        = regs_get_kernel_argument(regs, 1);
 	struct pt_regs *fault_regs =
 		(struct pt_regs *)regs_get_kernel_argument(regs, 2);
-	struct smptrace_map *tmp_map, map_copy = {0};
-	unsigned long flags;
-	bool found = false;
+	struct smptrace_map map = {0};
 	int ret;
 
 	// Only data aborts (There should not be any instruction aborts but...)
 	if (ESR_ELx_EC(esr) != ESR_ELx_EC_DABT_CUR)
 		return 0;
 
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_for_each_entry(tmp_map, &ctx->maps, list) {
-		if (fault_va >= tmp_map->va &&
-		    fault_va <  tmp_map->va + tmp_map->len) {
-			map_copy = *tmp_map;
-			found = true;
-			break;
-		}
-	}
-	spin_unlock_irqrestore(&ctx->lock, flags);
-
-	if (!found)
+	if (!smptrace_find_map_rcu(ctx, fault_va, &map))
 		return 0;
 
 	if (this_cpu_xchg(*ctx->in_pf, true)) {
@@ -442,7 +429,7 @@ static int __enter_do_kernel_fault(struct kprobe *kp, struct pt_regs *regs)
 	}
 
 	// God bless fixed-width opcode ISAs
-	ret = emulate_arm64_fault(ctx, &map_copy, fault_va, esr, fault_regs);
+	ret = emulate_arm64_fault(ctx, &map, fault_va, esr, fault_regs);
 	this_cpu_write(*ctx->in_pf, false);
 
 	if (!ret) {

--- a/kernel/trace/arch/riscv/smptrace_arch.c
+++ b/kernel/trace/arch/riscv/smptrace_arch.c
@@ -102,7 +102,7 @@ static unsigned long riscv_level2size(unsigned int level)
 	}
 }
 
-int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+int smptrace_arch_poison_pte(struct smptrace_map *map)
 {
 	unsigned long satp = csr_read(CSR_SATP);
 	unsigned long va = map->va;
@@ -163,7 +163,7 @@ fail:
 	return ret;
 }
 
-void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+void smptrace_arch_restore_pte(struct smptrace_map *map)
 {
 	unsigned long satp = csr_read(CSR_SATP);
 	unsigned long va = map->va;

--- a/kernel/trace/arch/riscv/smptrace_arch.c
+++ b/kernel/trace/arch/riscv/smptrace_arch.c
@@ -462,9 +462,7 @@ static int __enter_riscv_handle_page_fault(struct kprobe *kp,
 		(struct pt_regs *)regs_get_kernel_argument(regs, 0);
 	unsigned long fault_va = fault_regs->badaddr;
 	unsigned long cause    = fault_regs->cause;
-	struct smptrace_map *tmp_map, map_copy = {0};
-	unsigned long flags;
-	bool found = false;
+	struct smptrace_map map = {0};
 	int ret;
 
 	if (cause != EXC_LOAD_PAGE_FAULT && cause != EXC_STORE_PAGE_FAULT)
@@ -473,18 +471,7 @@ static int __enter_riscv_handle_page_fault(struct kprobe *kp,
 	if (user_mode(fault_regs))
 		return 0;
 
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_for_each_entry(tmp_map, &ctx->maps, list) {
-		if (fault_va >= tmp_map->va &&
-		    fault_va <  tmp_map->va + tmp_map->len) {
-			map_copy = *tmp_map;
-			found = true;
-			break;
-		}
-	}
-	spin_unlock_irqrestore(&ctx->lock, flags);
-
-	if (!found)
+	if (!smptrace_find_map_rcu(ctx, fault_va, &map))
 		return 0;
 
 	if (this_cpu_xchg(*ctx->in_pf, true)) {
@@ -492,7 +479,7 @@ static int __enter_riscv_handle_page_fault(struct kprobe *kp,
 		return 0;
 	}
 
-	ret = emulate_riscv_fault(ctx, &map_copy, fault_va, fault_regs);
+	ret = emulate_riscv_fault(ctx, &map, fault_va, fault_regs);
 	this_cpu_write(*ctx->in_pf, false);
 
 	if (!ret) {

--- a/kernel/trace/arch/riscv/smptrace_arch.c
+++ b/kernel/trace/arch/riscv/smptrace_arch.c
@@ -104,6 +104,7 @@ static unsigned long riscv_level2size(unsigned int level)
 
 int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
+	unsigned long satp = csr_read(CSR_SATP);
 	unsigned long va = map->va;
 	int64_t remain = map->len;
 	struct smptrace_pte *orig, *tmp;
@@ -111,7 +112,7 @@ int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 
 	while (remain > 0) {
 		unsigned int level;
-		pte_t *ptep = riscv_walk_pte(va, &level, ctx->riscv_kernel_satp);
+		pte_t *ptep = riscv_walk_pte(va, &level, satp);
 
 		if (!ptep) {
 			ret = -ENOENT;
@@ -164,12 +165,13 @@ fail:
 
 void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
 {
+	unsigned long satp = csr_read(CSR_SATP);
 	unsigned long va = map->va;
 	int64_t remain = map->len;
 
 	while (remain > 0) {
 		unsigned int level;
-		pte_t *ptep = riscv_walk_pte(va, &level, ctx->riscv_kernel_satp);
+		pte_t *ptep = riscv_walk_pte(va, &level, satp);
 		struct smptrace_pte *orig;
 		unsigned long step;
 
@@ -503,9 +505,11 @@ static int __enter_riscv_handle_page_fault(struct kprobe *kp,
 
 int smptrace_arch_activate(struct smptrace_ctx *ctx)
 {
+	unsigned long satp;
+	
 	// Maybe we could do w/o SATP but it should point to kernel page tables on this context
-	ctx->riscv_kernel_satp = csr_read(CSR_SATP);
-	if (!ctx->riscv_kernel_satp) {
+	satp = csr_read(CSR_SATP);
+	if (!satp) {
 		pr_err("SATP is zero — MMU not enabled?\n");
 		return -EINVAL;
 	}

--- a/kernel/trace/arch/x86/smptrace_arch.c
+++ b/kernel/trace/arch/x86/smptrace_arch.c
@@ -274,24 +274,10 @@ static int __enter_badarea(struct kprobe *kp, struct pt_regs *regs)
 	struct smptrace_ctx *ctx = container_of(kp, struct smptrace_ctx, badarea_kp);
 	struct pt_regs *pf_regs  = (struct pt_regs *)regs_get_kernel_argument(regs, 0);
 	unsigned long pf_va      = regs_get_kernel_argument(regs, 2);
-	struct smptrace_map *tmp_map, map_copy = {0};
-	unsigned long flags;
-	bool found = false;
+	struct smptrace_map map = {0};
 	int ret;
 
-	/* Find the matching memory mapping. We copy it by value so we don't hold the spinlock 
-	   during the entire emulate_pf_instruction sequence (which triggers user callbacks). */
-	spin_lock_irqsave(&ctx->lock, flags);
-	list_for_each_entry(tmp_map, &ctx->maps, list) {
-		if (pf_va >= tmp_map->va && pf_va < tmp_map->va + tmp_map->len) {
-			map_copy = *tmp_map;
-			found = true;
-			break;
-		}
-	}
-	spin_unlock_irqrestore(&ctx->lock, flags);
-
-	if (!found)
+	if (!smptrace_find_map_rcu(ctx, pf_va, &map))
 		return 0;
 
 	if (this_cpu_xchg(*ctx->in_pf, true)) {
@@ -299,7 +285,7 @@ static int __enter_badarea(struct kprobe *kp, struct pt_regs *regs)
 		return 0;
 	}
 
-	ret = emulate_pf_instruction(ctx, &map_copy, pf_regs);
+	ret = emulate_pf_instruction(ctx, &map, pf_regs);
 	this_cpu_write(*ctx->in_pf, false);
 
     /* Update return address to skip the whole function we hooked */

--- a/kernel/trace/arch/x86/smptrace_arch.c
+++ b/kernel/trace/arch/x86/smptrace_arch.c
@@ -42,7 +42,7 @@ static u64 level2size(unsigned int level)
 	}
 }
 
-int smptrace_arch_poison_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+int smptrace_arch_poison_pte(struct smptrace_map *map)
 {
 	int64_t remain = map->len;
 	unsigned long va = map->va;
@@ -119,7 +119,7 @@ fail:
 	return ret;
 }
 
-void smptrace_arch_restore_pte(struct smptrace_ctx *ctx, struct smptrace_map *map)
+void smptrace_arch_restore_pte(struct smptrace_map *map)
 {
 	unsigned long va = map->va;
 	int64_t remain = map->len;

--- a/kernel/trace/smptrace.c
+++ b/kernel/trace/smptrace.c
@@ -247,14 +247,12 @@ static void smptrace_deactivate(struct smptrace_ctx *ctx)
 	struct smptrace_map *map, *tmp;
 	unsigned long flags;
 
-	/* First, stop hooks on ioremap and iounmap so everyone stops updating
-	 * ctx->traced_va */
+	/* First, stop hooks on ioremap and iounmap so everyone stops adding
+	 * and removing poisoned PTEs */
 	unregister_kretprobe(&ctx->ioremap_krp);
 	unregister_kprobe(&ctx->iounmap_kp);
 
-	/* Stop #PF hook now that we shouldn't be hitting #PF */
-	unregister_kprobe(&ctx->badarea_kp);
-
+	/* Now unpoison PTEs so that we stop hitting #PF */
 	spin_lock_irqsave(&ctx->lock, flags);
 	list_for_each_entry_safe(map, tmp, &ctx->maps, list) {
 		list_del(&map->list);
@@ -266,6 +264,9 @@ static void smptrace_deactivate(struct smptrace_ctx *ctx)
 		spin_lock_irqsave(&ctx->lock, flags);
 	}
 	spin_unlock_irqrestore(&ctx->lock, flags);
+
+	/* Stop #PF hook now that we shouldn't be hitting #PF */
+	unregister_kprobe(&ctx->badarea_kp);
 
 	if (ctx->shadow_va) {
 		iounmap(ctx->shadow_va);

--- a/kernel/trace/smptrace.c
+++ b/kernel/trace/smptrace.c
@@ -42,6 +42,7 @@
 #include <linux/sched.h>
 #include <linux/ptrace.h>
 #include <linux/version.h>
+#include <linux/rculist.h>
 #include <asm/io.h>
 #include <asm/tlbflush.h>
 #include "trace/smptrace.h"
@@ -150,7 +151,7 @@ int smptrace_exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 		        va, args->len, args->pa, args->len);
 	} else {
 		spin_lock_irqsave(&ctx->lock, flags);
-		list_add_tail(&map->list, &ctx->maps);
+		list_add_tail_rcu(&map->list, &ctx->maps);
 		spin_unlock_irqrestore(&ctx->lock, flags);
 	}
 
@@ -169,7 +170,7 @@ int smptrace_enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
 	list_for_each_entry(map, &ctx->maps, list) {
 		if (map->va == va) {
 			found = map;
-			list_del(&map->list);
+			list_del_rcu(&map->list);
 			break;
 		}
 	}
@@ -181,7 +182,7 @@ int smptrace_enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
 	pr_info("restoring VA=0x%lx (PA=0x%llx)", found->va,
 	        (unsigned long long)found->pa);
 	smptrace_arch_restore_pte(found);
-	kfree(found);
+	kfree_rcu(found, rcu);
 	return 0;
 }
 
@@ -255,11 +256,11 @@ static void smptrace_deactivate(struct smptrace_ctx *ctx)
 	/* Now unpoison PTEs so that we stop hitting #PF */
 	spin_lock_irqsave(&ctx->lock, flags);
 	list_for_each_entry_safe(map, tmp, &ctx->maps, list) {
-		list_del(&map->list);
+		list_del_rcu(&map->list);
 		spin_unlock_irqrestore(&ctx->lock, flags);
 
 		smptrace_arch_restore_pte(map);
-		kfree(map);
+		kfree_rcu(map, rcu);
 
 		spin_lock_irqsave(&ctx->lock, flags);
 	}

--- a/kernel/trace/smptrace.c
+++ b/kernel/trace/smptrace.c
@@ -140,7 +140,7 @@ int smptrace_exit_ioremap(struct kretprobe_instance *ri, struct pt_regs *regs)
 	pr_info("poisoning VA=0x%lx:%lx (PA=0x%llx:%lx)",
 	        va, args->len, (unsigned long long)ctx->pa, ctx->len);
 
-	if (smptrace_arch_poison_pte(ctx, map)) {
+	if (smptrace_arch_poison_pte(map)) {
 		kfree(map);
 
 		regs_set_return_value(regs, 0);
@@ -180,7 +180,7 @@ int smptrace_enter_iounmap(struct kprobe *kp, struct pt_regs *regs)
 
 	pr_info("restoring VA=0x%lx (PA=0x%llx)", found->va,
 	        (unsigned long long)found->pa);
-	smptrace_arch_restore_pte(ctx, found);
+	smptrace_arch_restore_pte(found);
 	kfree(found);
 	return 0;
 }
@@ -260,7 +260,7 @@ static void smptrace_deactivate(struct smptrace_ctx *ctx)
 		list_del(&map->list);
 		spin_unlock_irqrestore(&ctx->lock, flags);
 
-		smptrace_arch_restore_pte(ctx, map);
+		smptrace_arch_restore_pte(map);
 		kfree(map);
 
 		spin_lock_irqsave(&ctx->lock, flags);


### PR DESCRIPTION
* Remove the need to keep a SATP snapshot in RISC-V code.
* Cleanup PTE poison/unpoison arch callbacks to only take a `struct smptrace_map`.
* Correct the order of operations in `smptrace_destroy()`.
* Use RCU so that instruction emulation can fully run in parallel. That is, without grabbing any locks to find the matching poisoned PTE for a page fault.